### PR TITLE
fix markdown rendering on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------
-erw-l3 --- Utilities built around expl3
-Source repository: https://github.com/er-cpp/erw-l3
-Released under the LaTeX Project Public License v1.3c or later
-See http://www.latex-project.org/lppl.txt
-----------------------------------------------------------------
+erw-l3 --- Utilities built around expl3  
+Source repository: https://github.com/er-cpp/erw-l3  
+Released under the LaTeX Project Public License v1.3c or later  
+See http://www.latex-project.org/lppl.txt  
 
+----------------------------------------------------------------


### PR DESCRIPTION
- append spaces for line breaking
- add blank line not to be recognized as header `h2`