### PR TITLE
load expl3 before `\ProvidesExplPackage` to fix Undefined control sequence

### DIFF
--- a/erw-l3.sty
+++ b/erw-l3.sty
@@ -11,13 +11,13 @@
 %% See http://www.latex-project.org/lppl.txt
 %% ----------------------------------------------------------------
 %% 
+\RequirePackage{expl3}[2018/06/01]
 \ProvidesExplPackage
   {erw-l3}              % Package name
   {2018/6/22}     % Release date
   {0.1.4}                 % Release version
   {Utilities built around expl3} % Description
 \NeedsTeXFormat{LaTeX2e}
-\RequirePackage{expl3}[2018/06/01]
 \RequirePackage{xparse}[2018/02/01]
 \RequirePackage{l3keys2e}
 \ExplSyntaxOn


### PR DESCRIPTION
To fix error like

```
(/usr/local/texlive/2018/texmf-dist/tex/latex/erw-l3/erw-l3.sty
! Undefined control sequence.
l.14 \ProvidesExplPackage
                         
?
```